### PR TITLE
Change network-monitor xnft-cli version to latest

### DIFF
--- a/packages/network-monitor/package.json
+++ b/packages/network-monitor/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@coral-xyz/xnft-cli": "^0.0.1",
+    "@coral-xyz/xnft-cli": "latest",
     "@parcel/config-default": "^2.7.0",
     "prettier": "2.7.1"
   },


### PR DESCRIPTION
Clean build was failing with `render root fn not found`
![image](https://user-images.githubusercontent.com/104461627/198025737-cefc926f-9b84-42cc-a170-cd904ba5bfac.png)
